### PR TITLE
provide detected language information

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     // other depends
-    implementation 'net.clojars.suuft:libretranslate-java:1.0.5'
+    implementation 'net.clojars.suuft:libretranslate-java:1.0.7'
 }
 ```
 
@@ -38,7 +38,7 @@ Depend:
 <dependency>
     <groupId>net.clojars.suuft</groupId>
     <artifactId>libretranslate-java</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.7</version>
 </dependency>
 ```
 ### `Usage:`

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'net.clojars.suuft'
-version '1.0.5'
+version '1.0.7'
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,16 @@ publishing {
     publications {
         gpr(MavenPublication) {
             from(components.java)
+
+
+            pom {
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://github.com/dynomake/libretranslate-java/blob/master/LICENSE'
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/java/net/suuft/libretranslate/Translator.java
+++ b/src/main/java/net/suuft/libretranslate/Translator.java
@@ -18,6 +18,10 @@ public class Translator {
     private String urlApi = "https://translate.fedilab.app/translate";
 
     public String translate(@NonNull String from, @NonNull String to, @NonNull String request) {
+        return translateDetect(from, to, request).getTranslatedText();
+    }
+
+    public TranslateResponse translateDetect(@NonNull String from, @NonNull String to, @NonNull String request) {
         try {
 
             URL url = new URL(urlApi);
@@ -42,7 +46,7 @@ public class Translator {
             Scanner s = new Scanner(responseStream).useDelimiter("\\A");
             String response = s.hasNext() ? s.next() : "";
 
-            return JsonUtil.from(response, TranslateResponse.class).getTranslatedText();
+            return JsonUtil.from(response, TranslateResponse.class);
         } catch (Exception e) {
             e.printStackTrace();
             throw new RuntimeException(e);
@@ -52,6 +56,10 @@ public class Translator {
     public String translate(@NonNull Language from, @NonNull Language to, @NonNull String request) {
         if (to == Language.NONE || from == to) return request;
         return translate(from.getCode(), to.getCode(), request);
+    }
+
+    public TranslateResponse translateDetect(@NonNull Language to, @NonNull String request) {
+        return translateDetect("auto", to.getCode(), request);
     }
 
     public String translate(@NonNull Language to, @NonNull String request) {

--- a/src/main/java/net/suuft/libretranslate/type/TranslateResponse.java
+++ b/src/main/java/net/suuft/libretranslate/type/TranslateResponse.java
@@ -10,4 +10,14 @@ import lombok.experimental.FieldDefaults;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class TranslateResponse {
     String translatedText;
+
+    DetectedLanguage detectedLanguage;
+
+    @Getter
+    @AllArgsConstructor
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    public static class DetectedLanguage {
+        int confidence;
+        String language;
+    }
 }


### PR DESCRIPTION
This relatively small change adds an alternative translate function, _translateDetect_, that returns more information about the detected language.

While testing this, I also found out that clojars now requires a license to be defined in the pom, which is why I've added the corresponding entries to the gradle.build files.

Finally, to reflect the two miniscule changes I bumped the version to 1.0.7 from 1.0.5

I've tested the changes, it compiles and runs as one would expect given the trivial nature of the changes.